### PR TITLE
Issue 9

### DIFF
--- a/src/pack-repo.py
+++ b/src/pack-repo.py
@@ -21,6 +21,7 @@ def is_recently_modified(file_path, days = 7):
         return time_difference <= timedelta(days=days).total_seconds()
     except FileNotFoundError:
         return False
+    
 # added by Steven Hur
 # simple message printer for --recent flag
 def write_recent_changes_summary(f, num_files):


### PR DESCRIPTION
This pull request adds '--recent' and '-r' flag feature. 

## changes:
- '--recent' and '-r' flag command line option is added
- Check file's last modified time and check if it was modified within last 7 days
- recent_output.txt file is removed from list
- "Recent Changes Summary" section is added to summarize the files 

## tests performed:
- Created two files that were edited a month ago
- Created two files that were edited few days ago
- 'python3 pack-repo.py . --recent --output recent_files.txt'
- recent_files.txt contains information of files that were modified within the 7 days.

Issue#9 is fixed