### PR TITLE
add support for TOML cnofiguration file

### DIFF
--- a/.pack-repo.template.toml
+++ b/.pack-repo.template.toml
@@ -1,0 +1,22 @@
+# This is an example configuration file for the Repo-Context-Packager.
+# To use it, copy this file to the same location with `pack-repo.py` and edit the values.
+# Command-line arguments will always override the settings in this file.
+# Priority Logic:
+# 1. Command-Line Arguments (Highest Priority)
+# 2. Values from .pack-repo.toml
+# 3. ardcoded Defaults
+
+# The name of the output file. If not set, output will be printed to the console.
+# output = "repo-context.txt"
+
+# Set to 'true' to include hidden files and folders (those starting with a '.').
+# all = false
+
+# Set to an integer to only include files modified within the last N days.
+# recent = 7
+
+# Set to 'true' to include line numbers in the file content output.
+# line-number = false
+
+# Set to 'true' to only show the directory structure without file contents.
+# dirs-only = false

--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ Details for arguments and options are listed below:
 | **--line-number, -l**     | Include line number when displaying file content output                |
 | **--dirs-only, -d**       | Show only directory structure tree without file contents               |
 
+## .TOML Configuration File
+You can use a ```.pack-repo.toml``` file in the project's root directory to set default options for this script.
+To get started, copy the template file to src/:
+```bash
+cp .pack-repo.toml.example .pack-repo.toml
+```
+Then, open and edit ```.pack-repo.toml``` to set your preferred defaults.
+**IMPORTANT:** Command-line arguments will always override any settings from the ```.pack-repo.toml``` file.
+
 ## License:
 
 This project is licensed under BSD 2-Clause License.

--- a/src/pack-repo.py
+++ b/src/pack-repo.py
@@ -2,6 +2,8 @@ import argparse
 import sys
 import re
 import time
+import tomli
+import os
 from pathlib import Path
 from git import Repo
 from pygments.lexers import guess_lexer_for_filename
@@ -185,8 +187,25 @@ if __name__ == "__main__":
     parser.add_argument("--line-number", "-l", action="store_true", help="Include line number when displaying file content output")
     parser.add_argument("--dirs-only", "-d", action="store_true", help="Show only directory structure tree without file contents")
 
-    args = parser.parse_args()
+    # Load configuration from pyproject.toml if it exists
+    CONFIG_FILE = ".pack-repo.toml"
+    config = {}
 
+    if os.path.exists(CONFIG_FILE):
+        try:
+            with open(CONFIG_FILE, "rb") as f:
+                config_from_file = tomli.load(f)
+                config = {k.replace('-', '_'): v for k, v in config_from_file.items()}
+        except tomli.TOMLDecodeError:
+            print(f"Error: Could not parse {CONFIG_FILE}. Please check its format.")
+            sys.exit(1)
+    
+    # merge config file options with argparse
+    if config:
+        parser.set_defaults(**config)
+
+    args = parser.parse_args()
+                
     #initialize variables
     paths = args.paths
     filename = args.output


### PR DESCRIPTION
#Key Changes
Configuration Loading: On startup, the script now checks for a `.pack-repo.toml` file in the current working directory. If the file is not found, the script runs as normal.

##Priority Logic
The configuration is applied with the following order of precedence, ensuring that user-provided arguments are always respected:
1. Command-Line Arguments (Highest Priority)
2. Values from `.pack-repo.toml`
3. Hardcoded Defaults (Lowest Priority)

Error Handling: If a `.pack-repo.toml` file is found but contains invalid syntax, the script will print a descriptive error message and exit gracefully.

Implementation: The feature is built using the `tomli` library for parsing and is integrated directly with `argparse` via `parser.set_defaults()` for a clean and robust implementation.

